### PR TITLE
Add a CMake based compilation option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # pkg-config to find it.
 include(FindPkgConfig)
 pkg_check_modules(CAPSTONE REQUIRED capstone)
-if(!CAPSTONE_FOUND)
-  message(FATAL_ERROR "Capstone not found")
-endif()
 
 add_compile_options(-Wall -Wextra -pedantic -Werror)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.14.0)
+project(
+  SpyCycles
+  LANGUAGES C
+  VERSION 1.0.0)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Capstone doesn't seem to provide a CMake config file, so we need to use
+# pkg-config to find it.
+include(FindPkgConfig)
+pkg_check_modules(CAPSTONE REQUIRED capstone)
+if(!CAPSTONE_FOUND)
+  message(FATAL_ERROR "Capstone not found")
+endif()
+
+add_compile_options(-Wall -Wextra -pedantic -Werror)
+
+# Create the spycycles executable
+add_executable(spycycles spycycles.c)
+
+target_include_directories(spycycles PRIVATE ${CAPSTONE_INCLUDE_DIRS})
+target_link_libraries(spycycles PRIVATE ${CAPSTONE_LIBRARIES})
+
+# Create a dummy hello world executable to test the tool
+add_executable(hello hello_world.c)
+
+# Install the spycycles executable
+include(GNUInstallDirs)
+install(TARGETS spycycles DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 BIN = spycycles
 SRC = spycycles.c
 LIBS = -lcapstone
-CFLAGS = -W -Wall
+CFLAGS = -Wall -Wextra -pedantic -Werror
 CC = gcc
 
 .PHONY: default
 default: $(BIN)
 
 .PHONY: all
-all: install default
+all: install_deps default
 
 $(BIN): $(SRC)
 	$(CC) $(CFLAGS) $(SRC) $(LIBS) -o $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ all: install default
 $(BIN): $(SRC)
 	$(CC) $(CFLAGS) $(SRC) $(LIBS) -o $(BIN)
 
-.PHONY: install
-install:
+.PHONY: install_deps
+install_deps:
 	sudo apt-get install libcapstone-dev
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ sudo apt-get install libcapstone-dev
 gcc -W -Wall spycycles.c -lcapstone -o spycycles
 ```
 
+Or using cmake:
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug # Or Release
+cmake --build build
+cmake --install build # To install the binary (might need sudo)
+```
+
 ## Run
 
 ```

--- a/hello_world.c
+++ b/hello_world.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void)
+{
+    printf("Hello, world!\n");
+    return 0;
+}


### PR DESCRIPTION
Adds a CMakeList.txt to make build the project via CMake. Also includes a dummy hello world program to test on. As in CMake the install command is dedicated to installing the produced software, renamed the install command from the Makefile to install_deps

This also updates the README to provide guidance on how to compile with
 Cmake.